### PR TITLE
Include dist/tests in npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 /node_modules
 /npm-debug.log
+/dist/tests


### PR DESCRIPTION
Looks like `dist/tests` was being included in the package:

```
232K    ./node_modules/heimdalljs-logger/dist/tests/index.js
```

Updated `npmignore` to exclude it.

Thanks for your time in reading!